### PR TITLE
Add fan motivation and virtual SNS environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,43 @@ The agents used in the following example implement exactly these questions:
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.sandbox.google.com/github/google-deepmind/concordia/blob/main/examples/tutorial.ipynb)
 
+### Idol fan motivation simulation
+
+The snippet below demonstrates how to run the virtual SNS environment and
+compare how `oshi` and `gachikoi` fans evaluate randomly generated events.
+
+```python
+from concordia.components.agent.fan_motivation import FanMotivation
+from concordia.environment.virtual_sns_environment import VirtualSnsEnvironment
+
+
+class DummyPlayer:
+    def __init__(self, fan_type: str):
+        self._fan_type = fan_type
+
+    def get_property(self, name: str) -> str:
+        if name == "fan_type":
+            return self._fan_type
+        raise KeyError(name)
+
+
+env = VirtualSnsEnvironment()
+oshi = FanMotivation(model=None, player=DummyPlayer("oshi"))
+gachikoi = FanMotivation(model=None, player=DummyPlayer("gachikoi"))
+
+# Advance one simulated day to give the environment a chance to emit events.
+for _ in range(24 * 60):
+    env.tick()
+
+for event in env.get_events():
+    print(event)
+    print("oshi reward:", oshi.evaluate_event(event))
+    print("gachikoi reward:", gachikoi.evaluate_event(event))
+```
+
+Running the code prints the random idol events along with the reward each fan
+type assigns to them.
+
 ## Citing Concordia
 
 If you use Concordia in your work, please cite the accompanying article:

--- a/concordia/components/agent/fan_motivation.py
+++ b/concordia/components/agent/fan_motivation.py
@@ -1,0 +1,73 @@
+# Copyright 2025 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Motivation component for idol fans."""
+
+from concordia.components.agent.motivation import Motive
+
+
+class FanMotivation(Motive):
+  """Custom motive for "oshi" and "gachikoi" fans."""
+
+  def __init__(self, model, player, **kwargs):
+    super().__init__(model, player, **kwargs)
+    # Player object provides fan_type attribute
+    self.fan_type = player.get_property('fan_type')
+
+  def _evaluate_event(self, event_statement: str) -> float:
+    """Evaluate event descriptions according to fan type.
+
+    This logic follows the user provided reward structure.
+    """
+    # 1. Praise focused on idol activities (concerts, fan service, etc.)
+    idol_praise_keywords = [
+        "idol performance",
+        "fan meeting",
+        "concert was a success",
+        "great singer",
+        "amazing dancer",
+        "handshake event",
+    ]
+    if any(keyword in event_statement.lower() for keyword in idol_praise_keywords):
+      # Both fan types receive the same high positive reward
+      return 10.0
+
+    # 2. Success in general entertainment activities (movies, commercials, etc.)
+    general_success_keywords = [
+        "starred in a movie",
+        "appeared in a commercial",
+        "won an acting award",
+        "published a photo book",
+        "variety show regular",
+    ]
+    if any(keyword in event_statement.lower() for keyword in general_success_keywords):
+      if self.fan_type == 'oshi':
+        return 5.0
+      if self.fan_type == 'gachikoi':
+        return 0.0
+
+    # 3. Reports about private life (dating scandals, rumors, etc.)
+    private_life_keywords = [
+        "dating scandal",
+        "relationship rumor",
+        "seen in private with",
+    ]
+    if any(keyword in event_statement.lower() for keyword in private_life_keywords):
+      if self.fan_type == 'oshi':
+        return 3.0
+      if self.fan_type == 'gachikoi':
+        return -10.0
+
+    # Default to parent class evaluation if none of the above match
+    return super()._evaluate_event(event_statement)

--- a/concordia/components/agent/motivation.py
+++ b/concordia/components/agent/motivation.py
@@ -1,0 +1,54 @@
+# Copyright 2025 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base classes for motives used by agents."""
+
+from concordia.typing import entity_component
+
+
+class Motive(entity_component.ComponentWithLogging):
+  """Base motive component.
+
+  Subclasses should override `_evaluate_event` to return a numeric reward
+  for a given event description.
+  """
+
+  def __init__(self, model, player, **kwargs):
+    del kwargs
+    super().__init__()
+    self._model = model
+    self._player = player
+
+  def get_state(self) -> entity_component.ComponentState:
+    """Returns the (stateless) component state."""
+    return {}
+
+  def set_state(self, state: entity_component.ComponentState) -> None:
+    """Restores the component state (no-op)."""
+    del state
+    return None
+
+  def evaluate_event(self, event_statement: str) -> float:
+    """Evaluate an event statement and return a reward."""
+    reward = self._evaluate_event(event_statement)
+    self._logging_channel({'Key': 'Reward', 'Value': reward})
+    return reward
+
+  def _evaluate_event(self, event_statement: str) -> float:
+    """Default evaluation returning neutral reward.
+
+    Subclasses should override this method.
+    """
+    del event_statement
+    return 0.0

--- a/concordia/environment/base.py
+++ b/concordia/environment/base.py
@@ -1,0 +1,48 @@
+# Copyright 2025 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simple base environment."""
+
+import datetime
+from collections.abc import Sequence
+
+
+class Environment:
+  """Lightweight environment base class."""
+
+  def __init__(self, scenario=None, *args, **kwargs):
+    del args, kwargs
+    self.scenario = scenario
+    self._time = datetime.datetime.now()
+    self._events: list[str] = []
+
+  def tick(self) -> None:
+    """Advance internal clock by one minute."""
+    self._time += datetime.timedelta(minutes=1)
+
+  def get_time(self) -> datetime.datetime:
+    """Return the current simulation time."""
+    return self._time
+
+  def broadcast_event(self, event_statement: str) -> None:
+    """Record a broadcast event.
+
+    Subclasses may override this method to notify agents. Here we simply
+    store the events in an internal list.
+    """
+    self._events.append(event_statement)
+
+  def get_events(self) -> Sequence[str]:
+    """Return the list of broadcast events."""
+    return tuple(self._events)

--- a/concordia/environment/virtual_sns_environment.py
+++ b/concordia/environment/virtual_sns_environment.py
@@ -1,0 +1,58 @@
+# Copyright 2025 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Environment that randomly emits idol related events."""
+
+import random
+import pandas as pd  # pylint: disable=unused-import
+
+from concordia.environment.base import Environment
+
+
+class VirtualSnsEnvironment(Environment):
+  """A virtual SNS environment emitting entertainment news."""
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    # Attempt to derive idol name from scenario configuration; fallback to literal
+    try:
+      self.idol_name = self.scenario.get_player_by_name('Idol').name
+    except Exception:  # pylint: disable=broad-except
+      self.idol_name = 'Idol'
+
+    self._possible_events = [
+        # Praise of idol specific activities
+        f"{self.idol_name}'s idol performance at the concert was a success.",
+        f"{self.idol_name}'s fan meeting was highly praised by attendees.",
+        f"Fans are excited about {self.idol_name}'s amazing dancing in the new music video.",
+        # Success in broader entertainment activities
+        f"{self.idol_name} has been cast to star in a new movie.",
+        f"{self.idol_name} will appear in a new nationwide commercial.",
+        f"{self.idol_name} won a prestigious acting award.",
+        # Private life reports
+        f"A dating scandal involving {self.idol_name} was reported by a magazine.",
+        f"There is a relationship rumor about {self.idol_name}.",
+        # Other general events
+        f"{self.idol_name} announced a new single release.",
+        f"A documentary about {self.idol_name}'s journey will be aired.",
+    ]
+
+  def tick(self):
+    super().tick()
+    current_time = self.get_time()
+    # Trigger a random event at 18:00 each day with 25% probability
+    if current_time.hour == 18 and current_time.minute == 0 and random.random() < 0.25:
+      event_statement = random.choice(self._possible_events)
+      # Broadcast the event so all agents may observe it
+      self.broadcast_event(event_statement)


### PR DESCRIPTION
## Summary
- Add base Motive component and FanMotivation to model different reward responses for `oshi` and `gachikoi` fans
- Introduce simple Environment base and VirtualSnsEnvironment that randomly broadcasts idol-related events
- Document how to run the fan motivation simulation in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688df0f59814832db10b027973dad2fb